### PR TITLE
Fix update_copyrights

### DIFF
--- a/scripts/update_copyrights
+++ b/scripts/update_copyrights
@@ -24,8 +24,8 @@ SOURCE_EXTENSIONS = {
 }
 
 HEADER_TEMPLATE = string.Template(
-"""${symbol} Copyright ${year} Contributors to the Veraison project.
-${symbol} SPDX-License-Identifier: Apache-2.0
+"""${begin_symbol} Copyright ${year} Contributors to the Veraison project.
+${end_symbol} SPDX-License-Identifier: Apache-2.0
 """
 )
 


### PR DESCRIPTION
Use begin_symbol and end_symbol for the copyright to ensure this works
correctly for C, Java, etc. files.