### PR TITLE
Fix Nonces repeated Unmarshalling

### DIFF
--- a/nonce.go
+++ b/nonce.go
@@ -43,7 +43,7 @@ func (ns *Nonces) UnmarshalCBOR(data []byte) error {
 		return err
 	}
 
-	*ns = append(*ns, n)
+	*ns = Nonces{n}
 
 	return nil
 }
@@ -126,7 +126,7 @@ func (ns *Nonces) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return err
 		}
-		*ns = append(*ns, Nonce{value})
+		*ns = Nonces{Nonce{value}}
 		return nil
 	default:
 		return errors.New("TODO handle array of nonces")

--- a/nonce_test.go
+++ b/nonce_test.go
@@ -162,3 +162,20 @@ func TestNonces_Validate(t *testing.T) {
 	}
 	assert.EqualError(ns3.Validate(), "a nonce must be between 8 and 64 bytes long; found 4")
 }
+
+func TestNonces_UnmarshalCBOR_Repeatedely(t *testing.T) {
+	assert := assert.New(t)
+	data := []byte{0x48, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef}
+	data2 := []byte{0x48, 0xab, 0xad, 0xca, 0xfe, 0xab, 0xad, 0xca, 0xfe}
+
+	expected := Nonces{Nonce{[]byte{0xab, 0xad, 0xca, 0xfe, 0xab, 0xad, 0xca, 0xfe}}}
+
+	actual := Nonces{}
+
+	err := actual.UnmarshalCBOR(data)
+	assert.Nil(err)
+	err = actual.UnmarshalCBOR(data2)
+	assert.Nil(err)
+
+	assert.Equal(expected, actual)
+}


### PR DESCRIPTION
Make sure that repeatedly calling UnmarshalCBOR on the same Nonces
instance overwrites previous values, rather than appending to the same
array.