### PR TITLE
Add CWT claims to EAT + dependant changes.

### DIFF
--- a/audience.go
+++ b/audience.go
@@ -1,0 +1,72 @@
+package eat
+
+import (
+	"encoding/json"
+	"errors"
+
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+// In the general case, the "aud" value is an array of case- sensitive strings,
+// each containing a StringOrURI value.  In the special case when the JWT has
+// one audience, the "aud" value MAY be a single case-sensitive string
+// containing a StringOrURI value.
+type Audience []StringOrURI
+
+// MarshalCBOR encodes Audience as a StringOrURI, in case there is only
+// one, or an array of StringOrURI's if there are multiple.
+func (a Audience) MarshalCBOR() ([]byte, error) {
+	if len(a) == 1 {
+		return cbor.Marshal(a[0])
+	}
+
+	return cbor.Marshal([]StringOrURI(a))
+}
+
+// UnmarshalCBOR decodes audience claim data. This may be a single StringOrURI,
+// or an array of such.
+func (a *Audience) UnmarshalCBOR(data []byte) error {
+	if isCBORArray(data) {
+		return cbor.Unmarshal(data, (*[]StringOrURI)(a))
+	}
+
+	var v StringOrURI
+
+	if err := cbor.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	*a = Audience{v}
+
+	return nil
+}
+
+// MarshalJSON encodes the receiver Audience as a JSON string
+func (a Audience) MarshalJSON() ([]byte, error) {
+	if len(a) == 1 {
+		return json.Marshal(a[0])
+	}
+
+	return nil, errors.New("TODO handle array of audiences")
+}
+
+// UnmarshalJSON decodes a JSON string into  the receiver Audience
+func (a *Audience) UnmarshalJSON(data []byte) error {
+	var v interface{}
+
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+
+	switch t := v.(type) {
+	case string:
+		var s StringOrURI
+		if err := s.FromString(t); err != nil {
+			return err
+		}
+		*a = Audience{s}
+		return nil
+	default:
+		return errors.New("TODO handle array of nonces")
+	}
+}

--- a/audience_test.go
+++ b/audience_test.go
@@ -1,0 +1,137 @@
+package eat
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAudience_MarshalCBOR_Multiple(t *testing.T) {
+	assert := assert.New(t)
+
+	s := "% Acme Inc. %"
+	u, err := url.Parse("http://example.com")
+	assert.Nil(err)
+
+	value := Audience{
+		StringOrURI{text: &s},
+		StringOrURI{uri: u},
+	}
+
+	//82                                            # array(2)
+	//   6d                                         # text(13)
+	//      252041636d6520496e632e2025              # "% Acme Inc. %"
+	//   d8 20                                      # tag(32)
+	//      72                                      # text(18)
+	//         687474703a2f2f6578616d706c652e636f6d # "http://example.com"
+	expected := []byte{
+		0x82, 0x6d, 0x25, 0x20, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49,
+		0x6e, 0x63, 0x2e, 0x20, 0x25, 0xd8, 0x20, 0x72, 0x68, 0x74,
+		0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x65, 0x78, 0x61, 0x6d, 0x70,
+		0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+	}
+
+	actual, err := value.MarshalCBOR()
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestAudience_MarshalCBOR_Single(t *testing.T) {
+	assert := assert.New(t)
+
+	s := "% Acme Inc. %"
+
+	value := Audience{StringOrURI{text: &s}}
+
+	// 6d                            # text(13)
+	//    252041636d6520496e632e2025 # "% Acme Inc. %"
+	expected := []byte{
+		0x6d, 0x25, 0x20, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x20, 0x25,
+	}
+
+	actual, err := value.MarshalCBOR()
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestAudience_UnmarshalCBOR_Multiple(t *testing.T) {
+	assert := assert.New(t)
+
+	s := "% Acme Inc. %"
+	u, err := url.Parse("http://example.com")
+	assert.Nil(err)
+
+	expected := Audience{
+		StringOrURI{text: &s},
+		StringOrURI{uri: u},
+	}
+
+	//82                                            # array(2)
+	//   6d                                         # text(13)
+	//      252041636d6520496e632e2025              # "% Acme Inc. %"
+	//   d8 20                                      # tag(32)
+	//      72                                      # text(18)
+	//         687474703a2f2f6578616d706c652e636f6d # "http://example.com"
+	data := []byte{
+		0x82, 0x6d, 0x25, 0x20, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49,
+		0x6e, 0x63, 0x2e, 0x20, 0x25, 0xd8, 0x20, 0x72, 0x68, 0x74,
+		0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x65, 0x78, 0x61, 0x6d, 0x70,
+		0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+	}
+
+	actual := Audience{}
+	err = actual.UnmarshalCBOR(data)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestAudience_UnmarshalCBOR_Single(t *testing.T) {
+	assert := assert.New(t)
+
+	s := "% Acme Inc. %"
+	u, err := url.Parse("http://example.com")
+	assert.Nil(err)
+
+	expected := Audience{StringOrURI{text: &s}}
+
+	actual := Audience{}
+
+	// 6d                            # text(13)
+	//    252041636d6520496e632e2025 # "% Acme Inc. %"
+	data := []byte{
+		0x6d, 0x25, 0x20, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x20, 0x25,
+	}
+
+	err = actual.UnmarshalCBOR(data)
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+
+	//81                                            # array(1)
+	//   6d                                         # text(13)
+	//      252041636d6520496e632e2025              # "% Acme Inc. %"
+	data2 := []byte{
+		0x81, 0x6d, 0x25, 0x20, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49,
+		0x6e, 0x63, 0x2e, 0x20, 0x25,
+	}
+
+	err = actual.UnmarshalCBOR(data2)
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+
+	// d8 20                                   # tag(32)
+	//    72                                   # text(18)
+	//          687474703a2f2f6578616d706c652e636f6d # "http://example.com"
+	data3 := []byte{
+		0xd8, 0x20, 0x72, 0x68, 0x74, 0x74, 0x70, 0x3a, 0x2f, 0x2f, 0x65,
+		0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x2e, 0x63, 0x6f, 0x6d,
+	}
+
+	expected3 := Audience{StringOrURI{uri: u}}
+
+	err = actual.UnmarshalCBOR(data3)
+	assert.Nil(err)
+	assert.Equal(expected3, actual)
+
+}

--- a/cwt.go
+++ b/cwt.go
@@ -1,0 +1,12 @@
+package eat
+
+// Defined by RFC8392
+type CWTClaims struct {
+	Issuer     *string      `cbor:"1,keyasint,omitempty" json:"iss,omitempty"`
+	Subject    *string      `cbor:"2,keyasint,omitempty" json:"sub,omitempty"`
+	Audience   *Audience    `cbor:"3,keyasint,omitempty" json:"aud,omitempty"`
+	Expiration *NumericDate `cbor:"4,keyasint,omitempty" json:"exp,omitempty"`
+	NotBefore  *NumericDate `cbor:"5,keyasint,omitempty" json:"nbf,omitempty"`
+	IssuedAt   *NumericDate `cbor:"6,keyasint,omitempty" json:"iat,omitempty"`
+	CwtID      *[]byte      `cbor:"7,keyasint,omitempty" json:"cti,omitempty"`
+}

--- a/eat.go
+++ b/eat.go
@@ -16,8 +16,9 @@ type Eat struct {
 	Debug         *Debug         `cbor:"16,keyasint,omitempty" json:"debug-disable,omitempty"`
 	Location      *Location      `cbor:"17,keyasint,omitempty" json:"location,omitempty"`
 	Uptime        *uint          `cbor:"19,keyasint,omitempty" json:"uptime,omitempty"`
+
+	CWTClaims
 	// TODO(tho) Submods claim (20)
-	// TODO(tho,setrofim) CWT claims
 }
 
 // FromCBOR deserializes the supplied CBOR encoded EAT into the receiver Eat

--- a/eat_test.go
+++ b/eat_test.go
@@ -5,6 +5,7 @@ package eat
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -24,6 +25,11 @@ var (
 	location    = Location{Latitude: 12.34, Longitude: 56.78}
 	uptime      = uint(60)
 
+	issuer   = AcmeInc
+	subject  = "rr-trap"
+	audience = Audience{origination}
+	epoch    = NumericDate(time.Unix(0, 0))
+
 	fatEat = Eat{
 		Nonce:         &Nonces{nonce},
 		UEID:          &ueID,
@@ -34,6 +40,16 @@ var (
 		Debug:         &debug,
 		Location:      &location,
 		Uptime:        &uptime,
+
+		CWTClaims: CWTClaims{
+			Issuer:     &issuer,
+			Subject:    &subject,
+			Audience:   &audience,
+			Expiration: &epoch,
+			NotBefore:  &epoch,
+			IssuedAt:   &epoch,
+			CwtID:      &oemID,
+		},
 	}
 )
 
@@ -66,7 +82,7 @@ func jsonRoundTripper(t *testing.T, tv Eat, expected string) {
 func TestEat_Full_RoundtripCBOR(t *testing.T) {
 	tv := fatEat
 	/*
-	   a9                                       # map(9)
+	   b0                                       # map(16)
 	      0a                                    # unsigned(10)
 	      44                                    # bytes(4)
 	         deadbeef                           # "\xDE\xAD\xBE\xEF"
@@ -93,16 +109,42 @@ func TestEat_Full_RoundtripCBOR(t *testing.T) {
 	         fb 404c63d70a3d70a4                # primitive(4633187891898314916)
 	      13                                    # unsigned(19)
 	      18 3c                                 # unsigned(60)
+	      01                                    # unsigned(1)
+	      69                                    # text(9)
+	         41636d6520496e632e                 # "Acme Inc."
+	      02                                    # unsigned(2)
+	      67                                    # text(7)
+	         72722d74726170                     # "rr-trap"
+	      03                                    # unsigned(3)
+	      69                                    # text(9)
+	         41636d6520496e632e                 # "Acme Inc."
+	      04                                    # unsigned(4)
+	      c1                                    # tag(1)
+	         00                                 # unsigned(0)
+	      05                                    # unsigned(5)
+	      c1                                    # tag(1)
+	         00                                 # unsigned(0)
+	      06                                    # unsigned(6)
+	      c1                                    # tag(1)
+	         00                                 # unsigned(0)
+	      07                                    # unsigned(7)
+	      46				    # bytes(6)
+	         ffffffffffff
 	*/
 	expected := []byte{
-		0xa9, 0x0a, 0x44, 0xde, 0xad, 0xbe, 0xef, 0x0b, 0x51, 0x01,
+		0xb0, 0x0a, 0x44, 0xde, 0xad, 0xbe, 0xef, 0x0b, 0x51, 0x01,
 		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
 		0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x0c, 0x69, 0x41, 0x63,
 		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x0d, 0x46, 0xff,
 		0xff, 0xff, 0xff, 0xff, 0xff, 0x0e, 0x03, 0x0f, 0xf5, 0x10,
 		0x01, 0x11, 0xa2, 0x01, 0xfb, 0x40, 0x28, 0xae, 0x14, 0x7a,
 		0xe1, 0x47, 0xae, 0x02, 0xfb, 0x40, 0x4c, 0x63, 0xd7, 0x0a,
-		0x3d, 0x70, 0xa4, 0x13, 0x18, 0x3c,
+		0x3d, 0x70, 0xa4, 0x13, 0x18, 0x3c, 0x01, 0x69, 0x41, 0x63,
+		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x02, 0x67, 0x72,
+		0x72, 0x2d, 0x74, 0x72, 0x61, 0x70, 0x03, 0x69, 0x41, 0x63,
+		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x04, 0xc1, 0x00,
+		0x05, 0xc1, 0x00, 0x06, 0xc1, 0x00, 0x07, 0x46, 0xff, 0xff,
+		0xff, 0xff, 0xff, 0xff,
 	}
 
 	cborRoundTripper(t, tv, expected)
@@ -123,7 +165,14 @@ func TestEat_Full_RoundtripJSON(t *testing.T) {
 		"long": 56.78
 	},
 	"ueid": "Ad6tvu/erb7v3q2+796tvu8=",
-	"uptime": 60
+	"uptime": 60,
+	"iss": "Acme Inc.",
+	"sub": "rr-trap",
+	"aud": "Acme Inc.",
+	"exp": 0,
+	"nbf": 0,
+	"iat": 0,
+	"cti": "////////"
 }`
 	jsonRoundTripper(t, tv, expected)
 }

--- a/numericdate.go
+++ b/numericdate.go
@@ -20,6 +20,21 @@ func (nd NumericDate) MarshalJSON() ([]byte, error) {
 	return []byte(strconv.FormatInt(t.Unix(), 10)), nil
 }
 
+// UnmarshalJSON populates the receiver NumericDate by interpreting the
+// supplied data as UTF-8-encoded Unix timestamp.
+func (nd *NumericDate) UnmarshalJSON(data []byte) error {
+	s := string(data)
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+
+	*nd = NumericDate(time.Unix(int64(i), 0))
+
+	return nil
+}
+
 // MarshalCBOR unwraps the receiver NumericDate exposing its underlying Time
 // and dispatches it to our custom encoding mode, which automatically adds the
 // required tag (TimeTag == cbor.EncTagRequired)
@@ -27,4 +42,17 @@ func (nd NumericDate) MarshalCBOR() ([]byte, error) {
 	t := time.Time(nd)
 
 	return em.Marshal(t)
+}
+
+// UnmarshalCBOR decodes the data into a Time and sets the receiver NumericDate
+// to the decoded value.
+func (nd *NumericDate) UnmarshalCBOR(data []byte) error {
+	var t time.Time
+	if err := dm.Unmarshal(data, &t); err != nil {
+		return err
+	}
+
+	*nd = NumericDate(t)
+
+	return nil
 }


### PR DESCRIPTION
- Add Audience type
- Add UnmarshalJSON and UnmarshalCBOR to NumericDate type.
- Add claims defined by CWT (RFC8392) as an embedded struct to EAT.