### PR TITLE
Switch to using cbor Modes

### DIFF
--- a/audience.go
+++ b/audience.go
@@ -3,8 +3,6 @@ package eat
 import (
 	"encoding/json"
 	"errors"
-
-	cbor "github.com/fxamacker/cbor/v2"
 )
 
 // In the general case, the "aud" value is an array of case- sensitive strings,
@@ -17,22 +15,22 @@ type Audience []StringOrURI
 // one, or an array of StringOrURI's if there are multiple.
 func (a Audience) MarshalCBOR() ([]byte, error) {
 	if len(a) == 1 {
-		return cbor.Marshal(a[0])
+		return em.Marshal(a[0])
 	}
 
-	return cbor.Marshal([]StringOrURI(a))
+	return em.Marshal([]StringOrURI(a))
 }
 
 // UnmarshalCBOR decodes audience claim data. This may be a single StringOrURI,
 // or an array of such.
 func (a *Audience) UnmarshalCBOR(data []byte) error {
 	if isCBORArray(data) {
-		return cbor.Unmarshal(data, (*[]StringOrURI)(a))
+		return dm.Unmarshal(data, (*[]StringOrURI)(a))
 	}
 
 	var v StringOrURI
 
-	if err := cbor.Unmarshal(data, &v); err != nil {
+	if err := dm.Unmarshal(data, &v); err != nil {
 		return err
 	}
 

--- a/nonce.go
+++ b/nonce.go
@@ -9,8 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
-	cbor "github.com/fxamacker/cbor/v2"
 )
 
 // A nonce-claim may be single Nonce or an array of two or more.
@@ -24,22 +22,22 @@ type Nonces []Nonce
 // one, or an array of byte strings if there are multiple.
 func (ns Nonces) MarshalCBOR() ([]byte, error) {
 	if len(ns) == 1 {
-		return cbor.Marshal(ns[0])
+		return em.Marshal(ns[0])
 	}
 
-	return cbor.Marshal([]Nonce(ns))
+	return em.Marshal([]Nonce(ns))
 }
 
 // UnmarshalCBOR decodes nonce claim data. This may be a single byte string
 // between 8 and 64 bytes long, or an array of two or more such strings.
 func (ns *Nonces) UnmarshalCBOR(data []byte) error {
 	if isCBORArray(data) {
-		return cbor.Unmarshal(data, (*[]Nonce)(ns))
+		return dm.Unmarshal(data, (*[]Nonce)(ns))
 	}
 
 	var n Nonce
 
-	if err := cbor.Unmarshal(data, &n); err != nil {
+	if err := dm.Unmarshal(data, &n); err != nil {
 		return err
 	}
 
@@ -78,14 +76,14 @@ type Nonce struct {
 
 // MarshalCBOR encodes the Nonce a CBOR byte string.
 func (n Nonce) MarshalCBOR() ([]byte, error) {
-	return cbor.Marshal(n.value)
+	return em.Marshal(n.value)
 }
 
 // UnmarshalCBOR decodes a CBOR byte string and uses it as the Nonce value.
 func (n *Nonce) UnmarshalCBOR(data []byte) error {
 	var value []byte
 
-	if err := cbor.Unmarshal(data, &value); err != nil {
+	if err := dm.Unmarshal(data, &value); err != nil {
 		return err
 	}
 

--- a/stringoruri.go
+++ b/stringoruri.go
@@ -88,11 +88,11 @@ func (s StringOrURI) ToURL() (*url.URL, error) {
 func (s StringOrURI) MarshalCBOR() ([]byte, error) {
 	if s.IsURI() {
 		tag := cbor.Tag{Number: 32, Content: s.uri.String()}
-		return cbor.Marshal(tag)
+		return em.Marshal(tag)
 	}
 
 	if s.text != nil {
-		return cbor.Marshal(s.text)
+		return em.Marshal(s.text)
 	}
 
 	return []byte{}, nil
@@ -108,7 +108,7 @@ func (s *StringOrURI) UnmarshalCBOR(data []byte) error {
 
 	if isCBORTextString(data) {
 		var value string
-		err := cbor.Unmarshal(data, &value)
+		err := dm.Unmarshal(data, &value)
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ func (s *StringOrURI) UnmarshalCBOR(data []byte) error {
 		}
 	} else if isCBORTag(data) {
 		var tag cbor.Tag
-		err := cbor.Unmarshal(data, &tag)
+		err := dm.Unmarshal(data, &tag)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Switch to using the cbor.EncMode and cbor.DecMode for marshalling in
order to ensure consistent application of marshalling options.