### PR TITLE
use canonical encoding (RFC 7049 3.9)

### DIFF
--- a/cbor.go
+++ b/cbor.go
@@ -12,6 +12,7 @@ var (
 
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
+		Sort:          cbor.SortCanonical,
 		IndefLength:   cbor.IndefLengthForbidden,
 		TimeTag:       cbor.EncTagRequired,
 		ShortestFloat: cbor.ShortestFloat16,

--- a/eat_test.go
+++ b/eat_test.go
@@ -94,69 +94,68 @@ func jsonRoundTripper(t *testing.T, tv Eat, expected string) {
 func TestEat_Full_RoundtripCBOR(t *testing.T) {
 	tv := fatEat
 	/*
-	   b0                                       # map(16)
-	      0a                                    # unsigned(10)
-	      44                                    # bytes(4)
-	         deadbeef                           # "\xDE\xAD\xBE\xEF"
-	      0b                                    # unsigned(11)
-	      51		                    # bytes(17)
-	         01deadbeefdeadbeefdeadbeefdeadbeef # "\x01\xDE\xAD\[...]xBE\xEF"
-	      0c                                    # unsigned(12)
-	      69                                    # text(9)
-	         41636d6520496e632e                 # "Acme Inc."
-	      0d                                    # unsigned(13)
-	      46                                    # bytes(6)
-	         ffffffffffff                       # "\xFF\xFF\xFF\xFF\xFF\xFF"
-	      0e                                    # unsigned(14)
-	      03                                    # unsigned(3)
-	      0f                                    # unsigned(15)
-	      f5                                    # primitive(21)
-	      10                                    # unsigned(16)
-	      01                                    # unsigned(1)
-	      11                                    # unsigned(17)
-	      a2                                    # map(2)
-	         01                                 # unsigned(1)
-	         fb 4028ae147ae147ae                # primitive(4623136420479977390)
-	         02                                 # unsigned(2)
-	         fb 404c63d70a3d70a4                # primitive(4633187891898314916)
-	      13                                    # unsigned(19)
-	      18 3c                                 # unsigned(60)
-	      01                                    # unsigned(1)
-	      69                                    # text(9)
-	         41636d6520496e632e                 # "Acme Inc."
-	      02                                    # unsigned(2)
-	      67                                    # text(7)
-	         72722d74726170                     # "rr-trap"
-	      03                                    # unsigned(3)
-	      69                                    # text(9)
-	         41636d6520496e632e                 # "Acme Inc."
-	      04                                    # unsigned(4)
-	      c1                                    # tag(1)
-	         00                                 # unsigned(0)
-	      05                                    # unsigned(5)
-	      c1                                    # tag(1)
-	         00                                 # unsigned(0)
-	      06                                    # unsigned(6)
-	      c1                                    # tag(1)
-	         00                                 # unsigned(0)
-	      07                                    # unsigned(7)
-	      46				    # bytes(6)
-	         ffffffffffff
+	   b0                                      # map(16)
+	      01                                   # unsigned(1)
+	      69                                   # text(9)
+	         41636d6520496e632e                # "Acme Inc."
+	      02                                   # unsigned(2)
+	      67                                   # text(7)
+	         72722d74726170                    # "rr-trap"
+	      03                                   # unsigned(3)
+	      69                                   # text(9)
+	         41636d6520496e632e                # "Acme Inc."
+	      04                                   # unsigned(4)
+	      c1                                   # tag(1)
+	         00                                # unsigned(0)
+	      05                                   # unsigned(5)
+	      c1                                   # tag(1)
+	         00                                # unsigned(0)
+	      06                                   # unsigned(6)
+	      c1                                   # tag(1)
+	         00                                # unsigned(0)
+	      07                                   # unsigned(7)
+	      46                                   # bytes(6)
+	         ffffffffffff                      # "\xFF\xFF\xFF\xFF\xFF\xFF"
+	      0a                                   # unsigned(10)
+	      44                                   # bytes(4)
+	         deadbeef                          # "\xDE\xAD\xBE\xEF"
+	      0b                                   # unsigned(11)
+	      51                                   # bytes(17)
+	         01deadbeefdeadbeefdeadbeefdeadbeef # "\x01\xDE\xAD\xBE\xEF\xDE\xAD\xBE\xEF\xDE\xAD\xBE\xEF\xDE\xAD\xBE\xEF"
+	      0c                                   # unsigned(12)
+	      69                                   # text(9)
+	         41636d6520496e632e                # "Acme Inc."
+	      0d                                   # unsigned(13)
+	      46                                   # bytes(6)
+	         ffffffffffff                      # "\xFF\xFF\xFF\xFF\xFF\xFF"
+	      0e                                   # unsigned(14)
+	      03                                   # unsigned(3)
+	      0f                                   # unsigned(15)
+	      f5                                   # primitive(21)
+	      10                                   # unsigned(16)
+	      01                                   # unsigned(1)
+	      11                                   # unsigned(17)
+	      a2                                   # map(2)
+	         01                                # unsigned(1)
+	         fb 4028ae147ae147ae               # primitive(4623136420479977390)
+	         02                                # unsigned(2)
+	         fb 404c63d70a3d70a4               # primitive(4633187891898314916)
+	      13                                   # unsigned(19)
+	      18 3c                                # unsigned(60)
 	*/
 	expected := []byte{
-		0xb0, 0x0a, 0x44, 0xde, 0xad, 0xbe, 0xef, 0x0b, 0x51, 0x01,
-		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad,
-		0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x0c, 0x69, 0x41, 0x63,
-		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x0d, 0x46, 0xff,
-		0xff, 0xff, 0xff, 0xff, 0xff, 0x0e, 0x03, 0x0f, 0xf5, 0x10,
-		0x01, 0x11, 0xa2, 0x01, 0xfb, 0x40, 0x28, 0xae, 0x14, 0x7a,
-		0xe1, 0x47, 0xae, 0x02, 0xfb, 0x40, 0x4c, 0x63, 0xd7, 0x0a,
-		0x3d, 0x70, 0xa4, 0x13, 0x18, 0x3c, 0x01, 0x69, 0x41, 0x63,
-		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x02, 0x67, 0x72,
-		0x72, 0x2d, 0x74, 0x72, 0x61, 0x70, 0x03, 0x69, 0x41, 0x63,
-		0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x04, 0xc1, 0x00,
-		0x05, 0xc1, 0x00, 0x06, 0xc1, 0x00, 0x07, 0x46, 0xff, 0xff,
-		0xff, 0xff, 0xff, 0xff,
+		0xb0, 0x01, 0x69, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63,
+		0x2e, 0x02, 0x67, 0x72, 0x72, 0x2d, 0x74, 0x72, 0x61, 0x70, 0x03,
+		0x69, 0x41, 0x63, 0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x04,
+		0xc1, 0x00, 0x05, 0xc1, 0x00, 0x06, 0xc1, 0x00, 0x07, 0x46, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0x0a, 0x44, 0xde, 0xad, 0xbe, 0xef,
+		0x0b, 0x51, 0x01, 0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef,
+		0xde, 0xad, 0xbe, 0xef, 0xde, 0xad, 0xbe, 0xef, 0x0c, 0x69, 0x41,
+		0x63, 0x6d, 0x65, 0x20, 0x49, 0x6e, 0x63, 0x2e, 0x0d, 0x46, 0xff,
+		0xff, 0xff, 0xff, 0xff, 0xff, 0x0e, 0x03, 0x0f, 0xf5, 0x10, 0x01,
+		0x11, 0xa2, 0x01, 0xfb, 0x40, 0x28, 0xae, 0x14, 0x7a, 0xe1, 0x47,
+		0xae, 0x02, 0xfb, 0x40, 0x4c, 0x63, 0xd7, 0x0a, 0x3d, 0x70, 0xa4,
+		0x13, 0x18, 0x3c,
 	}
 
 	cborRoundTripper(t, tv, expected)


### PR DESCRIPTION
Avoid intermittent failures in CBOR encoding tests due to non-deterministic ordering of fields.