### PR TITLE
Bring submods up to date (part 1)

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.  
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥75%
+name: cover ≥85%
 on: [push]
 jobs:
 

--- a/eat_test.go
+++ b/eat_test.go
@@ -25,8 +25,8 @@ var (
 	location    = Location{Latitude: 12.34, Longitude: 56.78}
 	uptime      = uint(60)
 	submods     = Submods{
-		SubmodName{"eat-claims"}: Submod{Eat{}},
-		SubmodName{"eat-token"}:  Submod{[]byte{0xd8, 0x3d, 0xd2, 0x41, 0xa0}},
+		"eat-claims": Submod{Eat{}},
+		"eat-token":  Submod{[]byte{0xd8, 0x3d, 0xd2, 0x41, 0xa0}},
 	}
 
 	issuer   = AcmeInc


### PR DESCRIPTION
This implements the trivial bit of https://github.com/ietf-rats-wg/eat/pull/67 that requires submod names to only be strings.

I also took the liberty to bump up the minimum required coverage to 85% (from 75%)